### PR TITLE
include/prereq-build.mk : Support for Ubuntu 18.04

### DIFF
--- a/wiswrt/rak/purewrt-rc2/include/prereq-build.mk
+++ b/wiswrt/rak/purewrt-rc2/include/prereq-build.mk
@@ -145,7 +145,7 @@ $(eval $(call SetupHostCommand,svn,Please install the Subversion client, \
 	svn --version | grep Subversion))
 
 $(eval $(call SetupHostCommand,git,Please install Git (git-core) >= 1.6.5, \
-	git clone 2>&1 | grep -- --recursive))
+	git --exec-path | xargs -I % -- grep -q -- --recursive %/git-submodule))
 
 $(eval $(call SetupHostCommand,file,Please install the 'file' package, \
 	file --version 2>&1 | grep file))


### PR DESCRIPTION
Updated check for 'git-core' to support ubuntu 18.04.

### Test 
`./build/envsetup.sh` was run in source and made a pass